### PR TITLE
Gap filler

### DIFF
--- a/controllers/log-summary.ts
+++ b/controllers/log-summary.ts
@@ -99,8 +99,8 @@ export default function (req: Request, res: Response): Promise<TimeSummary> {
         }
     }
 
-    const shouldFillGaps = (reqQuer.fill_gaps !== undefined) ? isSorted : false;
-
+    const shouldFillGaps: boolean = (reqQuer.fill_gaps !== undefined) ? isSorted : false;
+    const gran: Granularity = (reqQuer.granularity === "hour") ? "hour" : "day";
 
     return Log.aggregate(aggregation)
         .then(function (results: any[]): TimeBucket[] {
@@ -114,7 +114,7 @@ export default function (req: Request, res: Response): Promise<TimeSummary> {
             return timeSummary;
         }).then(function (timeSummary: TimeSummary) {
             if (shouldFillGaps) {
-                return fillGaps(timeSummary, dateRange(reqQuer), granularity(reqQuer, "hour"));
+                return fillGaps(timeSummary, dateRange(reqQuer), granularity(reqQuer, gran));
             } else {
                 return timeSummary;
             }

--- a/controllers/log-summary.ts
+++ b/controllers/log-summary.ts
@@ -273,7 +273,6 @@ export function fillGap(from: moment.Moment, to: moment.Moment, granularity: Gra
         return [];
     }
 
-    console.info("Filling gaps + " + granularity);
     const increasing: boolean = from.isBefore(to);
     const end = moment(to);
     if (increasing) {

--- a/controllers/log-summary.ts
+++ b/controllers/log-summary.ts
@@ -273,6 +273,7 @@ export function fillGap(from: moment.Moment, to: moment.Moment, granularity: Gra
         return [];
     }
 
+    console.info("Filling gaps + " + granularity);
     const increasing: boolean = from.isBefore(to);
     const end = moment(to);
     if (increasing) {

--- a/controllers/log-summary.ts
+++ b/controllers/log-summary.ts
@@ -8,7 +8,6 @@ import { getDateRange } from "./query-utils";
 
 import Log from "../lib/log";
 import { TimeBucket, TimeSummary } from "../lib/time-bucket";
-import Console from "../lib/console-utils";
 
 /**
  * @swagger
@@ -100,7 +99,6 @@ export default function (req: Request, res: Response): Promise<TimeSummary> {
         }
     }
 
-    console.info("isSorted = " + isSorted + " " + reqQuer.fill_gaps);
     const shouldFillGaps = (reqQuer.fill_gaps !== undefined) ? isSorted : false;
 
     return Log.aggregate(aggregation)
@@ -114,11 +112,9 @@ export default function (req: Request, res: Response): Promise<TimeSummary> {
             };
             return timeSummary;
         }).then(function (timeSummary: TimeSummary) {
-            console.info("fill gapes = " + shouldFillGaps);
             if (shouldFillGaps) {
                 return fillGaps(timeSummary);
             } else {
-                console.info("not filling");
                 return timeSummary;
             }
         }).then(function (timeSummary: TimeSummary) {
@@ -135,7 +131,6 @@ function sendOut(summary: TimeSummary, response: Response) {
 }
 
 function errorOut(error: Error, response: Response) {
-    Console.info("Error getting logs summary: " + error.message);
     response.status(400).send(error.message);
 }
 

--- a/test/controllers/log-summary-test.ts
+++ b/test/controllers/log-summary-test.ts
@@ -399,11 +399,10 @@ describe("Log time summary", function () {
             describe("Days Granularity", function () {
                 it("Tests the gaps are filled between the three buckets while increasing", function () {
                     const summary: TimeSummary = dummySummary(10, true, 5);
-                    console.log(summary);
+
                     const currentDay: moment.Moment = moment(summary.buckets[0].date);
                     return fillGaps(summary, {}, "day").then(function (newSummary: TimeSummary) {
 
-                        console.log(newSummary);
                         expect(newSummary.buckets).to.have.length(10 + 4 * 9); // original 10 + the 4 between each which are 9 gaps.
 
                         let j = 0;

--- a/test/controllers/log-summary-test.ts
+++ b/test/controllers/log-summary-test.ts
@@ -170,7 +170,6 @@ describe("Log time summary", function () {
 
                 const buckets: TimeBucket[] = fillGap(startDate, endDate);
 
-                console.log(buckets);
                 expect(buckets).to.have.length(24); // It won't include the end.
 
                 const checkDate = moment(startDate);
@@ -188,7 +187,6 @@ describe("Log time summary", function () {
 
                 const buckets: TimeBucket[] = fillGap(startDate, endDate);
 
-                console.log(buckets);
                 expect(buckets).to.have.length(24); // It won't include the end.
 
                 const checkDate = moment(startDate);
@@ -320,7 +318,6 @@ describe("Log time summary", function () {
 
                     const max = newSummary.buckets.length;
                     const maxMinusOne = max - 1;
-                    console.log(newSummary);
                     for (let i = 0; i < max; ++i) {
                         expect(newSummary.buckets[i].date).to.equalDate(checkDate.toDate());
                         if (i > 0 && i < maxMinusOne && i % 24 === 0) {

--- a/test/controllers/log-summary-test.ts
+++ b/test/controllers/log-summary-test.ts
@@ -171,14 +171,14 @@ describe("Log time summary", function () {
                 const buckets: TimeBucket[] = fillGap(startDate, endDate);
 
                 console.log(buckets);
-                expect(buckets).to.have.length(23); // It won't include the ends.
+                expect(buckets).to.have.length(24); // It won't include the end.
 
                 const checkDate = moment(startDate);
                 for (let bucket of buckets) {
-                    checkDate.add(1, "hour");
                     expect(bucket.count).to.equals(0);
                     expect(bucket.date).to.equalDate(checkDate.toDate());
                     expect(bucket.date).to.equalTime(checkDate.toDate());
+                    checkDate.add(1, "hour");
                 }
             });
 
@@ -189,14 +189,14 @@ describe("Log time summary", function () {
                 const buckets: TimeBucket[] = fillGap(startDate, endDate);
 
                 console.log(buckets);
-                expect(buckets).to.have.length(23); // It won't include the ends.
+                expect(buckets).to.have.length(24); // It won't include the end.
 
                 const checkDate = moment(startDate);
                 for (let bucket of buckets) {
-                    checkDate.subtract(1, "hour");
                     expect(bucket.count).to.equals(0);
                     expect(bucket.date).to.equalDate(checkDate.toDate());
                     expect(bucket.date).to.equalTime(checkDate.toDate());
+                    checkDate.subtract(1, "hour");
                 }
             });
 
@@ -206,8 +206,23 @@ describe("Log time summary", function () {
 
                 const buckets: TimeBucket[] = fillGap(startDate, endDate);
 
-                console.log(buckets);
-                expect(buckets).to.have.length(0);
+                expect(buckets).to.be.empty;
+            });
+
+            it ("Tests nothign is returned when the \"from\" parameter is undefined.", function() {
+                const endDate: moment.Moment = moment([2017, 0, 15]);
+
+                const buckets: TimeBucket[] = fillGap(undefined, endDate);
+
+                expect(buckets).to.be.empty;
+            });
+
+            it ("Tests nothign is returned when the \"to\" parameter is undefined.", function() {
+                const endDate: moment.Moment = moment([2017, 0, 15]);
+
+                const buckets: TimeBucket[] = fillGap(endDate, undefined);
+
+                expect(buckets).to.be.empty;
             });
         });
 
@@ -272,6 +287,24 @@ describe("Log time summary", function () {
 
                 return fillGaps(summary).then(function (newSummary: TimeSummary) {
                     expect(newSummary.buckets).to.have.length(0);
+                });
+            });
+
+            it ("Fills in gaps when a date range is provided.", function() {
+                const summary: TimeSummary = dummySummary(0, true);
+                const dateRange = { start_time: moment([2017, 0, 15]), end_time: moment([2017, 0, 16])};
+
+                const checkDate = moment(dateRange.start_time);
+
+                return fillGaps(summary, dateRange).then(function (newSummary: TimeSummary) {
+                    console.log(newSummary);
+                    expect(newSummary.buckets).to.have.length(25); // Should be 25 as in all day plus the ending hour.
+
+                    for (let i = 0; i < newSummary.buckets.length; ++i) {
+                        expect(newSummary.buckets[i].date).to.equalDate(checkDate.toDate());
+                        expect(newSummary.buckets[i].count).to.equal(0);
+                        checkDate.add(1, "hour");
+                    }
                 });
             });
         });

--- a/test/controllers/log-summary-test.ts
+++ b/test/controllers/log-summary-test.ts
@@ -164,169 +164,349 @@ describe("Log time summary", function () {
     describe("Fill gaps", function () {
         describe("function \"fillGap\"", function () {
 
-            it("Tests the gaps are fill in between the two dates that are increasing.", function () {
-                const startDate: moment.Moment = moment([2017, 0, 14]);
-                const endDate: moment.Moment = moment([2017, 0, 15]);
+            describe("Hour Granularity", function () {
+                it("Tests the gaps are fill in between the two dates that are increasing.", function () {
+                    const startDate: moment.Moment = moment([2017, 0, 14]);
+                    const endDate: moment.Moment = moment([2017, 0, 15]);
 
-                const buckets: TimeBucket[] = fillGap(startDate, endDate, "hour");
+                    const buckets: TimeBucket[] = fillGap(startDate, endDate, "hour");
 
-                expect(buckets).to.have.length(24); // It won't include the end.
+                    expect(buckets).to.have.length(24); // It won't include the end.
 
-                const checkDate = moment(startDate);
-                for (let bucket of buckets) {
-                    expect(bucket.count).to.equals(0);
-                    expect(bucket.date).to.equalDate(checkDate.toDate());
-                    expect(bucket.date).to.equalTime(checkDate.toDate());
-                    checkDate.add(1, "hour");
-                }
+                    const checkDate = moment(startDate);
+                    for (let bucket of buckets) {
+                        expect(bucket.count).to.equals(0);
+                        expect(bucket.date).to.equalDate(checkDate.toDate());
+                        expect(bucket.date).to.equalTime(checkDate.toDate());
+                        checkDate.add(1, "hour");
+                    }
+                });
+
+                it("Tests the gaps are fill in between the two dates that are increasing.", function () {
+                    const startDate: moment.Moment = moment([2017, 0, 15]);
+                    const endDate: moment.Moment = moment([2017, 0, 14]);
+
+                    const buckets: TimeBucket[] = fillGap(startDate, endDate, "hour");
+
+                    expect(buckets).to.have.length(24); // It won't include the end.
+
+                    const checkDate = moment(startDate);
+                    for (let bucket of buckets) {
+                        expect(bucket.count).to.equals(0);
+                        expect(bucket.date).to.equalDate(checkDate.toDate());
+                        expect(bucket.date).to.equalTime(checkDate.toDate());
+                        checkDate.subtract(1, "hour");
+                    }
+                });
+
+                it("Tests the gaps are not filled when dates are equal.", function () {
+                    const startDate: moment.Moment = moment([2017, 0, 15]);
+                    const endDate: moment.Moment = moment([2017, 0, 15]);
+
+                    const buckets: TimeBucket[] = fillGap(startDate, endDate, "hour");
+
+                    expect(buckets).to.be.empty;
+                });
+
+                it("Tests nothing is returned when the \"from\" parameter is undefined.", function () {
+                    const endDate: moment.Moment = moment([2017, 0, 15]);
+
+                    const buckets: TimeBucket[] = fillGap(undefined, endDate, "hour");
+
+                    expect(buckets).to.be.empty;
+                });
+
+                it("Tests nothing is returned when the \"to\" parameter is undefined.", function () {
+                    const endDate: moment.Moment = moment([2017, 0, 15]);
+
+                    const buckets: TimeBucket[] = fillGap(endDate, undefined, "hour");
+
+                    expect(buckets).to.be.empty;
+                });
             });
 
-            it("Tests the gaps are fill in between the two dates that are increasing.", function () {
-                const startDate: moment.Moment = moment([2017, 0, 15]);
-                const endDate: moment.Moment = moment([2017, 0, 14]);
+            describe("Day Granularity", function () {
+                it("Tests the gaps are fill in between the two dates that are increasing.", function () {
+                    const startDate: moment.Moment = moment([2017, 0, 14]);
+                    const endDate: moment.Moment = moment([2017, 0, 20]);
 
-                const buckets: TimeBucket[] = fillGap(startDate, endDate, "hour");
+                    const buckets: TimeBucket[] = fillGap(startDate, endDate, "day");
 
-                expect(buckets).to.have.length(24); // It won't include the end.
+                    expect(buckets).to.have.length(6); // It won't include the end.
 
-                const checkDate = moment(startDate);
-                for (let bucket of buckets) {
-                    expect(bucket.count).to.equals(0);
-                    expect(bucket.date).to.equalDate(checkDate.toDate());
-                    expect(bucket.date).to.equalTime(checkDate.toDate());
-                    checkDate.subtract(1, "hour");
-                }
-            });
+                    const checkDate = moment(startDate);
+                    for (let bucket of buckets) {
+                        expect(bucket.count).to.equals(0);
+                        expect(bucket.date).to.equalDate(checkDate.toDate());
+                        expect(bucket.date).to.equalTime(checkDate.toDate());
+                        checkDate.add(1, "day");
+                    }
+                });
 
-            it("Tests the gaps are not filled when dates are equal.", function () {
-                const startDate: moment.Moment = moment([2017, 0, 15]);
-                const endDate: moment.Moment = moment([2017, 0, 15]);
+                it("Tests the gaps are fill in between the two dates that are increasing.", function () {
+                    const startDate: moment.Moment = moment([2017, 0, 15]);
+                    const endDate: moment.Moment = moment([2017, 0, 10]);
 
-                const buckets: TimeBucket[] = fillGap(startDate, endDate, "hour");
+                    const buckets: TimeBucket[] = fillGap(startDate, endDate, "day");
 
-                expect(buckets).to.be.empty;
-            });
+                    expect(buckets).to.have.length(5); // It won't include the end.
 
-            it ("Tests nothign is returned when the \"from\" parameter is undefined.", function() {
-                const endDate: moment.Moment = moment([2017, 0, 15]);
+                    const checkDate = moment(startDate);
+                    for (let bucket of buckets) {
+                        expect(bucket.count).to.equals(0);
+                        expect(bucket.date).to.equalDate(checkDate.toDate());
+                        expect(bucket.date).to.equalTime(checkDate.toDate());
+                        checkDate.subtract(1, "day");
+                    }
+                });
 
-                const buckets: TimeBucket[] = fillGap(undefined, endDate, "hour");
+                it("Tests the gaps are not filled when dates are equal.", function () {
+                    const startDate: moment.Moment = moment([2017, 0, 15]);
+                    const endDate: moment.Moment = moment([2017, 0, 15]);
 
-                expect(buckets).to.be.empty;
-            });
+                    const buckets: TimeBucket[] = fillGap(startDate, endDate, "day");
 
-            it ("Tests nothign is returned when the \"to\" parameter is undefined.", function() {
-                const endDate: moment.Moment = moment([2017, 0, 15]);
+                    expect(buckets).to.be.empty;
+                });
 
-                const buckets: TimeBucket[] = fillGap(endDate, undefined, "hour");
+                it("Tests nothing is returned when the \"from\" parameter is undefined.", function () {
+                    const endDate: moment.Moment = moment([2017, 0, 15]);
 
-                expect(buckets).to.be.empty;
+                    const buckets: TimeBucket[] = fillGap(undefined, endDate, "day");
+
+                    expect(buckets).to.be.empty;
+                });
+
+                it("Tests nothing is returned when the \"to\" parameter is undefined.", function () {
+                    const endDate: moment.Moment = moment([2017, 0, 15]);
+
+                    const buckets: TimeBucket[] = fillGap(endDate, undefined, "day");
+
+                    expect(buckets).to.be.empty;
+                });
             });
         });
 
         describe("function \"fillGaps\"", function () {
-            it("Tests the gaps are filled between the three buckets while increasing", function () {
-                const summary: TimeSummary = dummySummary(10, true);
+            describe("Hours Granularity", function () {
 
-                const currentDay: moment.Moment = moment(summary.buckets[0].date);
-                return fillGaps(summary).then(function (newSummary: TimeSummary) {
-                    let j = 0;
-                    for (let i = 0; i < newSummary.buckets.length; i++) {
-                        // The day should be every 24 hours.
-                        if (i % 24 === 0) {
-                            expect(summary.buckets[j]).to.deep.equal(newSummary.buckets[i]);
-                            ++j;
-                        } else {
-                            expect(newSummary.buckets[i].date).to.equalDate(currentDay.toDate());
-                            expect(newSummary.buckets[i].count).to.equal(0);
+                it("Tests the gaps are filled between the three buckets while increasing", function () {
+                    const summary: TimeSummary = dummySummary(10, true);
+
+                    const currentDay: moment.Moment = moment(summary.buckets[0].date);
+                    return fillGaps(summary).then(function (newSummary: TimeSummary) {
+                        let j = 0;
+                        for (let i = 0; i < newSummary.buckets.length; i++) {
+                            // The day should be every 24 hours.
+                            if (i % 24 === 0) {
+                                expect(summary.buckets[j]).to.deep.equal(newSummary.buckets[i]);
+                                ++j;
+                            } else {
+                                expect(newSummary.buckets[i].date).to.equalDate(currentDay.toDate());
+                                expect(newSummary.buckets[i].count).to.equal(0);
+                            }
+                            currentDay.add(1, "hours");
                         }
-                        currentDay.add(1, "hours");
-                    }
+                    });
                 });
-            });
 
-            it("Tests the gaps are filled between the three buckets while decreasing", function () {
-                const summary: TimeSummary = dummySummary(10, false);
+                it("Tests the gaps are filled between the three buckets while decreasing", function () {
+                    const summary: TimeSummary = dummySummary(10, false);
 
-                const currentDay: moment.Moment = moment(summary.buckets[0].date);
-                return fillGaps(summary).then(function (newSummary: TimeSummary) {
-                    let j = 0;
-                    for (let i = 0; i < newSummary.buckets.length; i++) {
-                        // The day should be every 24 hours.
-                        if (i % 24 === 0) {
-                            expect(summary.buckets[j]).to.deep.equal(newSummary.buckets[i]);
-                            ++j;
-                        } else {
-                            expect(newSummary.buckets[i].date).to.equalDate(currentDay.toDate());
-                            expect(newSummary.buckets[i].count).to.equal(0);
+                    const currentDay: moment.Moment = moment(summary.buckets[0].date);
+                    return fillGaps(summary).then(function (newSummary: TimeSummary) {
+                        let j = 0;
+                        for (let i = 0; i < newSummary.buckets.length; i++) {
+                            // The day should be every 24 hours.
+                            if (i % 24 === 0) {
+                                expect(summary.buckets[j]).to.deep.equal(newSummary.buckets[i]);
+                                ++j;
+                            } else {
+                                expect(newSummary.buckets[i].date).to.equalDate(currentDay.toDate());
+                                expect(newSummary.buckets[i].count).to.equal(0);
+                            }
+                            currentDay.subtract(1, "hours");
                         }
-                        currentDay.subtract(1, "hours");
-                    }
+                    });
                 });
-            });
 
-            it("Tests the TimeSummary does not get updated.", function () {
-                const firstBucket: TimeBucket = { date: moment([2017, 0, 15]).toDate(), count: 100 };
-                const secondBucket: TimeBucket = { date: moment([2017, 0, 16]).toDate(), count: 200 };
-                const summary: TimeSummary = { buckets: [firstBucket, secondBucket] };
+                it("Tests the TimeSummary does not get updated.", function () {
+                    const firstBucket: TimeBucket = { date: moment([2017, 0, 15]).toDate(), count: 100 };
+                    const secondBucket: TimeBucket = { date: moment([2017, 0, 16]).toDate(), count: 200 };
+                    const summary: TimeSummary = { buckets: [firstBucket, secondBucket] };
 
-                return fillGaps(summary).then(function (newSummary: TimeSummary) {
-                    expect(summary.buckets).to.have.length(2);
-                    expect(summary).to.not.deep.equal(newSummary);
-                    expect(summary.buckets[0].date).to.equalDate(firstBucket.date);
-                    expect(summary.buckets[0].count).to.equal(firstBucket.count);
-                    expect(summary.buckets[1].date).to.equalDate(secondBucket.date);
-                    expect(summary.buckets[1].count).to.equal(secondBucket.count);
+                    return fillGaps(summary).then(function (newSummary: TimeSummary) {
+                        expect(summary.buckets).to.have.length(2);
+                        expect(summary).to.not.deep.equal(newSummary);
+                        expect(summary.buckets[0].date).to.equalDate(firstBucket.date);
+                        expect(summary.buckets[0].count).to.equal(firstBucket.count);
+                        expect(summary.buckets[1].date).to.equalDate(secondBucket.date);
+                        expect(summary.buckets[1].count).to.equal(secondBucket.count);
+                    });
                 });
-            });
 
-            it ("Tests that no bucket is filled when there are no buckets in summary.", function() {
-                const summary: TimeSummary = dummySummary(0, true);
+                it("Tests that no bucket is filled when there are no buckets in summary.", function () {
+                    const summary: TimeSummary = dummySummary(0, true);
 
-                return fillGaps(summary).then(function (newSummary: TimeSummary) {
-                    expect(newSummary.buckets).to.have.length(0);
+                    return fillGaps(summary).then(function (newSummary: TimeSummary) {
+                        expect(newSummary.buckets).to.have.length(0);
+                    });
                 });
-            });
 
-            it ("Fills in gaps when a date range is provided and summary is empty.", function() {
-                const summary: TimeSummary = dummySummary(0, true);
-                const dateRange = { start_time: moment([2017, 0, 15]), end_time: moment([2017, 0, 16])};
+                it("Fills in gaps when a date range is provided and summary is empty.", function () {
+                    const summary: TimeSummary = dummySummary(0, true);
+                    const dateRange = { start_time: moment([2017, 0, 15]), end_time: moment([2017, 0, 16]) };
 
-                const checkDate = moment(dateRange.start_time);
+                    const checkDate = moment(dateRange.start_time);
 
-                return fillGaps(summary, dateRange).then(function (newSummary: TimeSummary) {
-                    expect(newSummary.buckets).to.have.length(25); // Should be 25 as in all day plus the ending hour.
+                    return fillGaps(summary, dateRange).then(function (newSummary: TimeSummary) {
+                        expect(newSummary.buckets).to.have.length(25); // Should be 25 as in all day plus the ending hour.
 
-                    for (let i = 0; i < newSummary.buckets.length; ++i) {
-                        expect(newSummary.buckets[i].date).to.equalDate(checkDate.toDate());
-                        expect(newSummary.buckets[i].count).to.equal(0);
-                        checkDate.add(1, "hour");
-                    }
-                });
-            });
-
-            it ("Fills in gaps on ends when summary is provided.", function() {
-                const summary: TimeSummary = dummySummary(2, true);
-                const firstDate: moment.Moment = moment(summary.buckets[0].date).subtract(1, "days");
-                const lastDate: moment.Moment = moment(summary.buckets[summary.buckets.length - 1].date).add(1, "days");
-                const dateRange = { start_time: firstDate, end_time: lastDate};
-
-                const checkDate = moment(firstDate);
-
-                return fillGaps(summary, dateRange).then(function (newSummary: TimeSummary) {
-                    expect(newSummary.buckets).to.have.length(3 * 24 + 1); // Day before, day between, day after plus the hour that we started.
-
-                    const max = newSummary.buckets.length;
-                    const maxMinusOne = max - 1;
-                    for (let i = 0; i < max; ++i) {
-                        expect(newSummary.buckets[i].date).to.equalDate(checkDate.toDate());
-                        if (i > 0 && i < maxMinusOne && i % 24 === 0) {
-                            expect(newSummary.buckets[i].count).to.equal(100);
-                        } else {
+                        for (let i = 0; i < newSummary.buckets.length; ++i) {
+                            expect(newSummary.buckets[i].date).to.equalDate(checkDate.toDate());
                             expect(newSummary.buckets[i].count).to.equal(0);
+                            checkDate.add(1, "hour");
                         }
-                        checkDate.add(1, "hour");
-                    }
+                    });
+                });
+
+                it("Fills in gaps on ends when summary is provided.", function () {
+                    const summary: TimeSummary = dummySummary(2, true);
+                    const firstDate: moment.Moment = moment(summary.buckets[0].date).subtract(1, "days");
+                    const lastDate: moment.Moment = moment(summary.buckets[summary.buckets.length - 1].date).add(1, "days");
+                    const dateRange = { start_time: firstDate, end_time: lastDate };
+
+                    const checkDate = moment(firstDate);
+
+                    return fillGaps(summary, dateRange).then(function (newSummary: TimeSummary) {
+                        expect(newSummary.buckets).to.have.length(3 * 24 + 1); // Day before, day between, day after plus the hour that we started.
+
+                        const max = newSummary.buckets.length;
+                        const maxMinusOne = max - 1;
+                        for (let i = 0; i < max; ++i) {
+                            expect(newSummary.buckets[i].date).to.equalDate(checkDate.toDate());
+                            if (i > 0 && i < maxMinusOne && i % 24 === 0) {
+                                expect(newSummary.buckets[i].count).to.equal(100);
+                            } else {
+                                expect(newSummary.buckets[i].count).to.equal(0);
+                            }
+                            checkDate.add(1, "hour");
+                        }
+                    });
+                });
+            });
+
+            describe("Days Granularity", function () {
+                it("Tests the gaps are filled between the three buckets while increasing", function () {
+                    const summary: TimeSummary = dummySummary(10, true, 5);
+                    console.log(summary);
+                    const currentDay: moment.Moment = moment(summary.buckets[0].date);
+                    return fillGaps(summary, {}, "day").then(function (newSummary: TimeSummary) {
+
+                        console.log(newSummary);
+                        expect(newSummary.buckets).to.have.length(10 + 4 * 9); // original 10 + the 4 between each which are 9 gaps.
+
+                        let j = 0;
+                        for (let i = 0; i < newSummary.buckets.length; i++) {
+                            // The day should be every 24 hours.
+                            if (i % 5 === 0) {
+                                expect(summary.buckets[j]).to.deep.equal(newSummary.buckets[i]);
+                                ++j;
+                            } else {
+                                expect(newSummary.buckets[i].date).to.equalDate(currentDay.toDate());
+                                expect(newSummary.buckets[i].count).to.equal(0);
+                            }
+                            currentDay.add(1, "days");
+                        }
+                    });
+                });
+
+                it("Tests the gaps are filled between the three buckets while decreasing", function () {
+                    const summary: TimeSummary = dummySummary(10, false, 5);
+
+                    const currentDay: moment.Moment = moment(summary.buckets[0].date);
+                    return fillGaps(summary, {}, "day").then(function (newSummary: TimeSummary) {
+
+                        expect(newSummary.buckets).to.have.length(10 + 4 * 9); // original 10 + the 4 between each which are 9 gaps.
+
+                        let j = 0;
+                        for (let i = 0; i < newSummary.buckets.length; i++) {
+                            // The day should be every 24 hours.
+                            if (i % 5 === 0) {
+                                expect(summary.buckets[j]).to.deep.equal(newSummary.buckets[i]);
+                                ++j;
+                            } else {
+                                expect(newSummary.buckets[i].date).to.equalDate(currentDay.toDate());
+                                expect(newSummary.buckets[i].count).to.equal(0);
+                            }
+                            currentDay.subtract(1, "days");
+                        }
+                    });
+                });
+
+                xit("Tests the TimeSummary does not get updated.", function () {
+                    const firstBucket: TimeBucket = { date: moment([2017, 0, 15]).toDate(), count: 100 };
+                    const secondBucket: TimeBucket = { date: moment([2017, 0, 20]).toDate(), count: 200 };
+                    const summary: TimeSummary = { buckets: [firstBucket, secondBucket] };
+
+                    return fillGaps(summary, "days").then(function (newSummary: TimeSummary) {
+                        expect(summary.buckets).to.have.length(2);
+                        expect(summary).to.not.deep.equal(newSummary);
+                        expect(summary.buckets[0].date).to.equalDate(firstBucket.date);
+                        expect(summary.buckets[0].count).to.equal(firstBucket.count);
+                        expect(summary.buckets[1].date).to.equalDate(secondBucket.date);
+                        expect(summary.buckets[1].count).to.equal(secondBucket.count);
+                    });
+                });
+
+                xit("Tests that no bucket is filled when there are no buckets in summary.", function () {
+                    const summary: TimeSummary = dummySummary(0, true);
+
+                    return fillGaps(summary, "days").then(function (newSummary: TimeSummary) {
+                        expect(newSummary.buckets).to.have.length(0);
+                    });
+                });
+
+                xit("Fills in gaps when a date range is provided and summary is empty.", function () {
+                    const summary: TimeSummary = dummySummary(0, true);
+                    const dateRange = { start_time: moment([2017, 0, 15]), end_time: moment([2017, 0, 16]) };
+
+                    const checkDate = moment(dateRange.start_time);
+
+                    return fillGaps(summary, dateRange, "day").then(function (newSummary: TimeSummary) {
+                        expect(newSummary.buckets).to.have.length(25); // Should be 25 as in all day plus the ending hour.
+
+                        for (let i = 0; i < newSummary.buckets.length; ++i) {
+                            expect(newSummary.buckets[i].date).to.equalDate(checkDate.toDate());
+                            expect(newSummary.buckets[i].count).to.equal(0);
+                            checkDate.add(1, "days");
+                        }
+                    });
+                });
+
+                xit("Fills in gaps on ends when summary is provided.", function () {
+                    const summary: TimeSummary = dummySummary(2, true);
+                    const firstDate: moment.Moment = moment(summary.buckets[0].date).subtract(1, "days");
+                    const lastDate: moment.Moment = moment(summary.buckets[summary.buckets.length - 1].date).add(1, "days");
+                    const dateRange = { start_time: firstDate, end_time: lastDate };
+
+                    const checkDate = moment(firstDate);
+
+                    return fillGaps(summary, dateRange, "day").then(function (newSummary: TimeSummary) {
+                        expect(newSummary.buckets).to.have.length(3 * 24 + 1); // Day before, day between, day after plus the hour that we started.
+
+                        const max = newSummary.buckets.length;
+                        const maxMinusOne = max - 1;
+                        for (let i = 0; i < max; ++i) {
+                            expect(newSummary.buckets[i].date).to.equalDate(checkDate.toDate());
+                            if (i > 0 && i < maxMinusOne && i % 24 === 0) {
+                                expect(newSummary.buckets[i].count).to.equal(100);
+                            } else {
+                                expect(newSummary.buckets[i].count).to.equal(0);
+                            }
+                            checkDate.add(1, "days");
+                        }
+                    });
                 });
             });
         });
@@ -381,7 +561,7 @@ function dummyAggregates(num: number): Aggregate[] {
     return aggs;
 }
 
-function dummySummary(num: number, increasing: boolean): TimeSummary {
+function dummySummary(num: number, increasing: boolean, gapsBetweenDays: number = 1): TimeSummary {
     const summary: TimeSummary = {
         buckets: []
     };
@@ -393,9 +573,9 @@ function dummySummary(num: number, increasing: boolean): TimeSummary {
             count: 100
         });
         if (increasing) {
-            date.add(1, "days");
+            date.add(gapsBetweenDays, "days");
         } else {
-            date.subtract(1, "days");
+            date.subtract(gapsBetweenDays, "days");
         }
     }
     return summary;

--- a/test/controllers/log-summary-test.ts
+++ b/test/controllers/log-summary-test.ts
@@ -168,7 +168,7 @@ describe("Log time summary", function () {
                 const startDate: moment.Moment = moment([2017, 0, 14]);
                 const endDate: moment.Moment = moment([2017, 0, 15]);
 
-                const buckets: TimeBucket[] = fillGap(startDate, endDate);
+                const buckets: TimeBucket[] = fillGap(startDate, endDate, "hour");
 
                 expect(buckets).to.have.length(24); // It won't include the end.
 
@@ -185,7 +185,7 @@ describe("Log time summary", function () {
                 const startDate: moment.Moment = moment([2017, 0, 15]);
                 const endDate: moment.Moment = moment([2017, 0, 14]);
 
-                const buckets: TimeBucket[] = fillGap(startDate, endDate);
+                const buckets: TimeBucket[] = fillGap(startDate, endDate, "hour");
 
                 expect(buckets).to.have.length(24); // It won't include the end.
 
@@ -202,7 +202,7 @@ describe("Log time summary", function () {
                 const startDate: moment.Moment = moment([2017, 0, 15]);
                 const endDate: moment.Moment = moment([2017, 0, 15]);
 
-                const buckets: TimeBucket[] = fillGap(startDate, endDate);
+                const buckets: TimeBucket[] = fillGap(startDate, endDate, "hour");
 
                 expect(buckets).to.be.empty;
             });
@@ -210,7 +210,7 @@ describe("Log time summary", function () {
             it ("Tests nothign is returned when the \"from\" parameter is undefined.", function() {
                 const endDate: moment.Moment = moment([2017, 0, 15]);
 
-                const buckets: TimeBucket[] = fillGap(undefined, endDate);
+                const buckets: TimeBucket[] = fillGap(undefined, endDate, "hour");
 
                 expect(buckets).to.be.empty;
             });
@@ -218,7 +218,7 @@ describe("Log time summary", function () {
             it ("Tests nothign is returned when the \"to\" parameter is undefined.", function() {
                 const endDate: moment.Moment = moment([2017, 0, 15]);
 
-                const buckets: TimeBucket[] = fillGap(endDate, undefined);
+                const buckets: TimeBucket[] = fillGap(endDate, undefined, "hour");
 
                 expect(buckets).to.be.empty;
             });

--- a/test/lib/time-bucket-test.ts
+++ b/test/lib/time-bucket-test.ts
@@ -18,6 +18,7 @@ describe("Time Bucket Tests", function () {
     it("Tests the dates are sorted in to respective time buckets by day.", function () {
         let items: Item[] = [];
         let date: Date = new Date();
+        date.setDate(20);
         for (let i = 0; i < 10; i++) {
             for (let j = i; j < 10; j++) {
                 const newItem = new Item(new Date(date.toISOString()));


### PR DESCRIPTION
Time query now allows a "fill_gaps" query which will send data for hours or days in which no logs exist.