### PR TITLE
Transactions

### DIFF
--- a/controllers/log-summary.ts
+++ b/controllers/log-summary.ts
@@ -186,9 +186,7 @@ function getGroup(reqQuer: TimeQuery): any {
             day: { $dayOfMonth: "$timestamp" },
             year: { $year: "$timestamp" }
         },
-        count: {
-            $sum: 1
-        }
+        transactions: { $addToSet: "$transaction_id" }
     };
 
     if (reqQuer.granularity === "hour") {
@@ -400,8 +398,8 @@ class ParsedTimeBucket implements TimeBucket {
 
     constructor(value: any) {
         // The month parameter starts at 0 index where-as the query starts at 1.  So subtract 1.
-        this.date = new Date(value._id.year, value._id.month - 1, value._id.day, 0, 0, 0, 0),
-            this.count = value.count;
+        this.date = new Date(value._id.year, value._id.month - 1, value._id.day, 0, 0, 0, 0);
+        this.count = value.transactions.length;
 
         if (value._id.hour) {
             this.date.setHours(value._id.hour - 1);

--- a/scripts/testFillDb.js
+++ b/scripts/testFillDb.js
@@ -59,6 +59,7 @@ function createLogs(numOfEntries) {
     var month = 0;
     var day = 15;
     var hour = 0;
+    var transaction_id;
     var payloadGenerator = generateAmazonPayload;
     for (var i = 0; i < numOfEntries; ++i) {
         if (i % 4 === 0) {
@@ -75,14 +76,19 @@ function createLogs(numOfEntries) {
                 hour = ++hour % 24;
             }
             return new Date(year, month, day, hour);
-        }, payloadGenerator);
+        }, payloadGenerator, () => {
+            if (i % 2 === 0) {
+                transaction_id = guid();
+            }
+            return transaction_id;
+        });
 
         logEntries.push(nextEntry);
     }
     return logEntries;
 }
 
-function createEntry(index, getDate, generatePayload) {
+function createEntry(index, getDate, generatePayload, generateTransactionId) {
     var type;
     switch (index % 3) {
         case 0:
@@ -100,7 +106,7 @@ function createEntry(index, getDate, generatePayload) {
     const payload = generatePayload(payloadType, index);
     return {
         source: generateName(index),
-        transaction_id: guid(),
+        transaction_id: generateTransactionId(index),
         payload: payload,
         log_type: type,
         tags: [payloadType, "tag" + index, "tag" + index + 1],

--- a/test/controllers/log-summary-test.ts
+++ b/test/controllers/log-summary-test.ts
@@ -58,7 +58,7 @@ describe("Log time summary", function () {
             startOfToday.setHours(0, 0, 0, 0);
 
             return logSummary(mockRequest, mockResponse).then(function (summary: TimeSummary) {
-                // expect(logAggregate).to.have.been.calledOnce;  // Once is ideal, but it's calling three times for each device and total.  This can't be fixed until server upgrades to MongoDB 3.4.
+                // expect(logAggregate).to.have.been.calledOnce;  // Once is ideal, but it"s calling three times for each device and total.  This can"t be fixed until server upgrades to MongoDB 3.4.
                 expect(logAggregate).to.have.been.called;
 
                 expect(summary).to.exist;
@@ -157,7 +157,7 @@ describe("Log time summary", function () {
 
                     const buckets: TimeBucket[] = fillGap(startDate, endDate, "hour");
 
-                    expect(buckets).to.have.length(24); // It won't include the end.
+                    expect(buckets).to.have.length(24); // It won"t include the end.
 
                     const checkDate = moment(startDate);
                     for (let bucket of buckets) {
@@ -174,7 +174,7 @@ describe("Log time summary", function () {
 
                     const buckets: TimeBucket[] = fillGap(startDate, endDate, "hour");
 
-                    expect(buckets).to.have.length(24); // It won't include the end.
+                    expect(buckets).to.have.length(24); // It won"t include the end.
 
                     const checkDate = moment(startDate);
                     for (let bucket of buckets) {
@@ -218,7 +218,7 @@ describe("Log time summary", function () {
 
                     const buckets: TimeBucket[] = fillGap(startDate, endDate, "day");
 
-                    expect(buckets).to.have.length(6); // It won't include the end.
+                    expect(buckets).to.have.length(6); // It won"t include the end.
 
                     const checkDate = moment(startDate);
                     for (let bucket of buckets) {
@@ -235,7 +235,7 @@ describe("Log time summary", function () {
 
                     const buckets: TimeBucket[] = fillGap(startDate, endDate, "day");
 
-                    expect(buckets).to.have.length(5); // It won't include the end.
+                    expect(buckets).to.have.length(5); // It won"t include the end.
 
                     const checkDate = moment(startDate);
                     for (let bucket of buckets) {
@@ -563,7 +563,7 @@ interface Aggregate {
         day: number,
         year: number
     };
-    count: number;
+    transactions: string[];
 }
 
 function dummyAggregates(num: number): Aggregate[] {
@@ -575,7 +575,7 @@ function dummyAggregates(num: number): Aggregate[] {
                 day: i + 1,
                 year: i + 2000
             },
-            count: i
+            transactions: createGuuids(num)
         });
     }
     return aggs;
@@ -599,4 +599,22 @@ function dummySummary(num: number, increasing: boolean, gapsBetweenDays: number 
         }
     }
     return summary;
+}
+
+function createGuuids(num: number): string[] {
+    let guids: string[] = [];
+    for (let i = 0; i < num; ++i) {
+        guids.push(guid());
+    }
+    return guids;
+}
+
+function guid() {
+    function s4() {
+        return Math.floor((1 + Math.random()) * 0x10000)
+            .toString(16)
+            .substring(1);
+    }
+    return s4() + s4() + "-" + s4() + "-" + s4() + "-" +
+        s4() + "-" + s4() + s4() + s4();
 }


### PR DESCRIPTION
Rather than looking at all logs, the Logless server will now only count `transaction_id` that perform at specific times. This will close the gap for logs that are either stacktraces or outputs since these logs can't have their origins determined yet.