### PR TITLE
Swapping from ".action" to ".metadata.intentName" as the source

### DIFF
--- a/controllers/intent-summary.ts
+++ b/controllers/intent-summary.ts
@@ -108,10 +108,10 @@ export default function (req: Request, res: Response): Promise<CountResult> {
                         else: "$payload.request.type"
                     }
                 },
-                "google": "$payload.result.action"
+                "google": "$payload.result.metadata.intentName"
             },
             count: { $sum: 1 },
-            type: { $addToSet: { $ifNull: ["$payload.result.action", "$payload.request.type"] } },
+            type: { $addToSet: { $ifNull: ["$payload.result.metadata.intentName", "$payload.request.type"] } },
             origin: {
                 $addToSet: {
                     $cond: {
@@ -123,32 +123,6 @@ export default function (req: Request, res: Response): Promise<CountResult> {
             }
         }
     });
-
-
-    // aggregation.push({
-    //     $group: {
-    //         _id: {
-    //             $cond: {
-    //                 if: { $eq: ["$payload.request.type", "IntentRequest"] },
-    //                 then: "$payload.request.intent.name",
-    //                 else: {
-    //                     $ifNull: ["$payload.request.type", { $ifNull: ["$payload.result.action", "remaining"] }]
-    //                 }
-    //             }
-    //         },
-    //         type: { $addToSet: { $ifNull: ["$payload.result.action", "$payload.request.type"] } },
-    //         origin: {
-    //             $addToSet: {
-    //                 $cond: {
-    //                     if: { $ne: [{ $ifNull: ["$payload.request.type", "missing"] }, "missing"] },
-    //                     then: AMAZON_ALEXA,
-    //                     else: GOOGLE_HOME
-    //                 }
-    //             }
-    //         },
-    //         count: { $sum: 1 }
-    //     }
-    // });
 
     // Only push if there is a value "count_sort" in the request.
     if (reqQuer.count_sort) {

--- a/controllers/source-stats.ts
+++ b/controllers/source-stats.ts
@@ -119,7 +119,7 @@ export default function (req: Request, res: Response): Promise<SourceStats> {
             $project: {
                 "transaction_id": 1,
                 "payload.request.type": 1,
-                "payload.result.action": 1
+                "payload.result.metadata.intentName": 1
             },
         }, {
             // Match only the logs that we can use.
@@ -128,7 +128,7 @@ export default function (req: Request, res: Response): Promise<SourceStats> {
                 $or: [{
                     "payload.request.type": { $exists: true }
                 }, {
-                    "payload.result.action": { $exists: true }
+                    "payload.result.metadata.intentName": { $exists: true }
                 }]
             },
         }, {
@@ -142,7 +142,7 @@ export default function (req: Request, res: Response): Promise<SourceStats> {
                             then: Constants.AMAZON_ALEXA,
                             else: {
                                 $cond: {
-                                    if: { $ne: [{ $ifNull: ["$payload.result.action", "missing"] }, "missing"] },
+                                    if: { $ne: [{ $ifNull: ["$payload.result.metadata.intentName", "missing"] }, "missing"] },
                                     then: Constants.GOOGLE_HOME,
                                     else: Constants.UNKNOWN
                                 }
@@ -171,7 +171,7 @@ export default function (req: Request, res: Response): Promise<SourceStats> {
                 "log_type": 1,
                 "transaction_id": 1,
                 "payload.request.type": 1,
-                "payload.result.action": 1
+                "payload.result.metadata.intentName": 1
             },
         }, {
             // Group by transaction ID so all log types related will be covered.  This will capture log types that don't have a payload,
@@ -185,7 +185,7 @@ export default function (req: Request, res: Response): Promise<SourceStats> {
                             then: Constants.AMAZON_ALEXA,
                             else: {
                                 $cond: {
-                                    if: { $ne: [{ $ifNull: ["$payload.result.action", "missing"] }, "missing"] },
+                                    if: { $ne: [{ $ifNull: ["$payload.result.metadata.intentName", "missing"] }, "missing"] },
                                     then: Constants.GOOGLE_HOME,
                                     else: Constants.UNKNOWN
                                 }


### PR DESCRIPTION
Per feedback from @jkelvie. The "action" on Google Home was unreliable as it was optional for it to be in place. The IntentName is much more static and in-line with the Alexa framework.