### PR TITLE
Support for querying specific transaction by id.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true

--- a/controllers/query.ts
+++ b/controllers/query.ts
@@ -20,6 +20,11 @@ import {ServerConfig} from "../lib/server-config";
  *         description: Log source id
  *         required: true
  *         type: string
+ *       - name: transaction_id
+ *         in: query
+ *         description: Transaction id
+ *         required: false
+ *         type: string
  *       - name: start_time
  *         in: query
  *         description: The start period to get logs from (ISO format)
@@ -90,6 +95,10 @@ export default function (req, res) {
     if (req.query.start_time) {
         Object.assign(query.timestamp, { $gt: req.query.start_time });
     } // no default
+
+    if (req.query.transaction_id) {
+        Object.assign(query, { transaction_id: req.query.transaction_id })
+    }
 
     if (ServerConfig.debug_mode) {
         console.time("query-" + req.query.source);


### PR DESCRIPTION
#### Overview
- Issue: https://github.com/bespoken/logless-server/issues/39
- [x] Adds `.editorconfig`: so we can have standard config across text editors & IDEs.
- [ ] Updates endpoint `/v1/query?transaction_id=tx123`:
  - [x] Adds optional `transaction_id` param.
  - [ ] Adds optionals `transactions_before` & `transactions_after` params.